### PR TITLE
PFMD-614: bump: node version to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,5 @@ outputs:
   release-notes:
     description: The version's release notes
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
### SUMMARY
This PR bumps the node version from the outdated v12 to v20, to bring it in line with versions of node that are still in-life.

### RELEASE NOTES

bump: node version from v12 to v20
